### PR TITLE
Feature/issue 51/rename reader to scanner

### DIFF
--- a/src/main/java/com/bringframework/context/AnnotationConfigApplicationContext.java
+++ b/src/main/java/com/bringframework/context/AnnotationConfigApplicationContext.java
@@ -2,10 +2,10 @@ package com.bringframework.context;
 
 import com.bringframework.exception.NoSuchBeanException;
 import com.bringframework.exception.NoUniqueBeanException;
-import com.bringframework.reader.BeanDefinitionReader;
-import com.bringframework.reader.DefaultBeanDefinitionReader;
 import com.bringframework.registry.BeanDefinitionRegistry;
 import com.bringframework.registry.DefaultBeanDefinitionRegistry;
+import com.bringframework.scanner.BeanDefinitionScanner;
+import com.bringframework.scanner.DefaultBeanDefinitionScanner;
 import java.util.Map;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
@@ -22,7 +22,7 @@ public class AnnotationConfigApplicationContext implements ApplicationContext {
   public AnnotationConfigApplicationContext() {
     log.trace("Application context is collecting...");
     BeanDefinitionRegistry beanDefinitionRegistry = new DefaultBeanDefinitionRegistry();
-    BeanDefinitionReader beanDefinitionReader = new DefaultBeanDefinitionReader(
+    BeanDefinitionScanner beanDefinitionScanner = new DefaultBeanDefinitionScanner(
         beanDefinitionRegistry);
     //ConfigBeanDefinitionReader configBeanDefinitionReader = new ConfigBeanDefinitionReaderImpl(
     //  beanDefinitionRegistry);

--- a/src/main/java/com/bringframework/scanner/BeanDefinitionScanner.java
+++ b/src/main/java/com/bringframework/scanner/BeanDefinitionScanner.java
@@ -1,4 +1,4 @@
-package com.bringframework.reader;
+package com.bringframework.scanner;
 
 import com.bringframework.registry.BeanDefinition;
 import com.bringframework.registry.BeanDefinitionRegistry;
@@ -7,7 +7,7 @@ import com.bringframework.registry.BeanDefinitionRegistry;
  * Implementations of this interface are responsible for scanning package by given packageName
  * creating {@link BeanDefinition}s and registering them with a {@link BeanDefinitionRegistry}.
  */
-public interface BeanDefinitionReader {
+public interface BeanDefinitionScanner {
 
   /**
    * Registers beans from the specified package.

--- a/src/main/java/com/bringframework/scanner/ConfigBeanDefinitionScanner.java
+++ b/src/main/java/com/bringframework/scanner/ConfigBeanDefinitionScanner.java
@@ -1,4 +1,4 @@
-package com.bringframework.reader;
+package com.bringframework.scanner;
 
 import com.bringframework.registry.BeanDefinition;
 import com.bringframework.registry.BeanDefinitionRegistry;
@@ -8,7 +8,7 @@ import com.bringframework.registry.BeanDefinitionRegistry;
  * configuration beans creating {@link BeanDefinition}s and registering them with a
  * {@link BeanDefinitionRegistry}.
  */
-public interface ConfigBeanDefinitionReader {
+public interface ConfigBeanDefinitionScanner {
 
   /**
    * Register configuration beans from a given package.

--- a/src/main/java/com/bringframework/scanner/DefaultBeanDefinitionScanner.java
+++ b/src/main/java/com/bringframework/scanner/DefaultBeanDefinitionScanner.java
@@ -1,4 +1,4 @@
-package com.bringframework.reader;
+package com.bringframework.scanner;
 
 import static java.util.Objects.nonNull;
 import static java.util.function.Function.identity;
@@ -17,17 +17,17 @@ import lombok.extern.slf4j.Slf4j;
 import org.reflections.Reflections;
 
 /**
- * Default implementation of {@link BeanDefinitionReader}.
- * This Reader scans provided package name and registers found {@link BeanDefinition}s
+ * Default implementation of {@link BeanDefinitionScanner}.
+ * This Scanner reads provided package name and registers found {@link BeanDefinition}s
  * in a {@link BeanDefinitionRegistry}. By default, it looks for classes annotated
  * with {@link Component} annotation.
  */
 @Slf4j
-public class DefaultBeanDefinitionReader implements BeanDefinitionReader {
+public class DefaultBeanDefinitionScanner implements BeanDefinitionScanner {
 
   private final BeanDefinitionRegistry registry;
 
-  public DefaultBeanDefinitionReader(BeanDefinitionRegistry registry) {
+  public DefaultBeanDefinitionScanner(BeanDefinitionRegistry registry) {
     this.registry = registry;
   }
 

--- a/src/test/java/com/bringframework/reader/TestService.java
+++ b/src/test/java/com/bringframework/reader/TestService.java
@@ -1,4 +1,0 @@
-package com.bringframework.reader;
-
-public class TestService {
-}

--- a/src/test/java/com/bringframework/scanner/DefaultBeanDefinitionScannerTest.java
+++ b/src/test/java/com/bringframework/scanner/DefaultBeanDefinitionScannerTest.java
@@ -1,4 +1,4 @@
-package com.bringframework.reader;
+package com.bringframework.scanner;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -16,7 +16,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-class DefaultBeanDefinitionReaderTest {
+class DefaultBeanDefinitionScannerTest {
 
   @Mock
   private BeanDefinitionRegistry registry;
@@ -28,7 +28,7 @@ class DefaultBeanDefinitionReaderTest {
   private ArgumentCaptor<BeanDefinition> beanDefinitionArgumentCaptor;
 
   @InjectMocks
-  private DefaultBeanDefinitionReader underTest;
+  private DefaultBeanDefinitionScanner underTest;
 
   @Test
   void shouldRegisterBeans() {

--- a/src/test/java/com/bringframework/scanner/TestComponent.java
+++ b/src/test/java/com/bringframework/scanner/TestComponent.java
@@ -1,4 +1,4 @@
-package com.bringframework.reader;
+package com.bringframework.scanner;
 
 import com.bringframework.annotation.Autowired;
 import com.bringframework.annotation.Component;

--- a/src/test/java/com/bringframework/scanner/TestService.java
+++ b/src/test/java/com/bringframework/scanner/TestService.java
@@ -1,0 +1,4 @@
+package com.bringframework.scanner;
+
+public class TestService {
+}


### PR DESCRIPTION
## Describe your changes

## Issue #51 Rename BeanDefinitionReader -> BeanDefinitionScanner
## Checklist before requesting a review
- [ ] There are no MR remarks
- [ x ] Clean and concise code that is easy to read and understand
- [ x ] Code covered with tests and they are green
- [ x ] Code API has informative JavaDoc on it
- [ x ] Rich logging with detailed messages and correct use of log levels
